### PR TITLE
Update IO.hsc

### DIFF
--- a/Bindings/Netcode/IO.hsc
+++ b/Bindings/Netcode/IO.hsc
@@ -165,7 +165,7 @@ import Prelude                ( IO, Eq, Show, Num
 #ccall netcode_server_disconnect_all_clients, Ptr <netcode_server_t> -> IO ()
 #ccall netcode_server_next_packet_sequence, Ptr <netcode_server_t> -> CInt -> IO Word64
 #ccall netcode_server_send_packet, Ptr <netcode_server_t> -> CInt -> Ptr Word8 -> CInt -> IO ()
-#ccall netcode_server_receive_packet, Ptr <netcode_server_t> -> CInt -> Ptr Int -> Ptr Word64 -> IO (Ptr Word8)
+#ccall netcode_server_receive_packet, Ptr <netcode_server_t> -> CInt -> Ptr CInt -> Ptr Word64 -> IO (Ptr Word8)
 #ccall netcode_server_free_packet, Ptr <netcode_server_t> -> Ptr () -> IO ()
 #ccall netcode_server_num_connected_clients, Ptr <netcode_server_t> -> IO CInt
 #ccall netcode_server_client_user_data, Ptr <netcode_server_t> -> CInt -> IO (Ptr ())

--- a/Bindings/Netcode/IO.hsc
+++ b/Bindings/Netcode/IO.hsc
@@ -165,7 +165,7 @@ import Prelude                ( IO, Eq, Show, Num
 #ccall netcode_server_disconnect_all_clients, Ptr <netcode_server_t> -> IO ()
 #ccall netcode_server_next_packet_sequence, Ptr <netcode_server_t> -> CInt -> IO Word64
 #ccall netcode_server_send_packet, Ptr <netcode_server_t> -> CInt -> Ptr Word8 -> CInt -> IO ()
-#ccall netcode_server_receive_packet, Ptr <netcode_server_t> -> CInt -> Ptr Word8 -> Ptr Word64 -> IO (Ptr Word8)
+#ccall netcode_server_receive_packet, Ptr <netcode_server_t> -> CInt -> Ptr Int -> Ptr Word64 -> IO (Ptr Word8)
 #ccall netcode_server_free_packet, Ptr <netcode_server_t> -> Ptr () -> IO ()
 #ccall netcode_server_num_connected_clients, Ptr <netcode_server_t> -> IO CInt
 #ccall netcode_server_client_user_data, Ptr <netcode_server_t> -> CInt -> IO (Ptr ())


### PR DESCRIPTION
On line 168, the third parameter for `netcode_server_receive_packet` is incorrectly marked as `Ptr Word8`. This parameter stores the size of the packet that is received by the server, and is marked as an `int` in the C code. Because it is marked as `Word8` in the Haskell binding, it can't store the size of packets bigger than 255 bytes, which results in truncated packets in the Haskell code.

This change fixes it.